### PR TITLE
Add `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ethereum-lists/chains",
+  "type": "module",
+  "files": [
+    "_data"
+  ],
+  "exports": {
+    "./*": "./_data/chains/*",
+    "./icons/*": "./_data/icons/*",
+    "./iconsDownload/*": "./_data/iconsDownload/*"
+  }
+}


### PR DESCRIPTION
This PR adds a very basic `package.json` file at the root so this repo can be installed in JS projects using the repo URL:

```bash
npm install https://github.com/ethereum-lists/chains.git
```

After running the command above, data in the repo will be accessible as such:

```typescript
// Accessing data in `_data/chains/`
import mainnet from "@ethereum-lists/chains/eip155-1.json" with { type: "json" };

console.log(mainnet); // { name: "Ethereum Mainnet", ... }

// Accessing data in `_data/icons/`
import mainnetIcons from "@ethereum-lists/chains/icons/ethereum.json" with { type: "json" };

console.log(mainnetIcons); // [{ url: "ipfs://...", ... }, ...]

// Accessing data in `_data/iconsDownload/`
import fs from "fs";
const icon = fs.readFileSync(new URL(import.meta.resolve(`@ethereum-lists/chains/iconsDownload/QmdwQDr6vmBtXmK2TmknkEuZNoaDqTasFdZdu3DRw8b2wt`)));

console.log(icon); // <Buffer ...>
```

---

This PR requires no publishing or CI/CD changes to keep things simple. An improved approach can be implemented in the future that involves multiple packages (`@ethereum-lists/chains`, `@ethereum-lists/icons`, `@ethereum-lists/iconsDownload`) and workflows to actually publish packages to NPM.